### PR TITLE
Fixes to show SBRs to Manage Kafka Connections

### DIFF
--- a/frontend/packages/rhoas-plugin/src/topology/components/rhoasComponentFactory.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/components/rhoasComponentFactory.ts
@@ -21,7 +21,7 @@ import {
 import { kebabOptionsToMenu } from '@console/internal/components/utils';
 import KafkaNode from './KafkaNode';
 import { rhoasActions } from '../actions/rhoasActions';
-import { MANAGED_KAFKA_TOPOLOGY_TYPE } from '../const';
+import { TYPE_MANAGED_KAFKA_CONNECTION } from './const';
 
 export const rhoasContextMenu = (element: Node) => {
   return createMenuItems(kebabOptionsToMenu(rhoasActions(element)));
@@ -31,7 +31,7 @@ export const getRhoasComponentFactory = (): ComponentFactory => {
   return (kind, type): React.ComponentType<{ element: GraphElement }> | undefined => {
     switch (type) {
       // Using resource kind as model kind for simplicity
-      case MANAGED_KAFKA_TOPOLOGY_TYPE:
+      case TYPE_MANAGED_KAFKA_CONNECTION:
         return withCreateConnector(
           createConnectorCallback(),
           CreateConnector,

--- a/frontend/packages/rhoas-plugin/src/topology/const.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/const.ts
@@ -1,1 +1,0 @@
-export const MANAGED_KAFKA_TOPOLOGY_TYPE = 'KafkaConnection';

--- a/frontend/packages/rhoas-plugin/src/topology/rhoas-data-transformer.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/rhoas-data-transformer.ts
@@ -1,11 +1,17 @@
-import { Model, NodeModel } from '@patternfly/react-topology';
+import { EdgeModel, Model, NodeModel } from '@patternfly/react-topology';
 import { apiVersionForModel, K8sResourceKind } from '@console/internal/module/k8s';
 import { getTopologyNodeItem } from '@console/topology/src/data-transforms/transform-utils';
 import { OverviewItem } from '@console/shared/src';
 import { TopologyDataObject, TopologyDataResources } from '@console/topology/src/topology-types';
-import { KAFKA_WIDTH, KAFKA_HEIGHT, KAFKA_PADDING } from './components/const';
-import { MANAGED_KAFKA_TOPOLOGY_TYPE } from './const';
+import {
+  KAFKA_WIDTH,
+  KAFKA_HEIGHT,
+  KAFKA_PADDING,
+  TYPE_MANAGED_KAFKA_CONNECTION,
+} from './components/const';
 import { KafkaConnectionModel } from '../models';
+import { edgesFromServiceBinding } from '@console/topology/src/operators/operators-data-transformer';
+import { TYPE_SERVICE_BINDING } from '@console/topology/src/const';
 
 const KAFKA_PROPS = {
   width: KAFKA_WIDTH,
@@ -37,7 +43,7 @@ export const getTopologyRhoasNodes = (kafkaConnections: K8sResourceKind[]): Node
     const data: TopologyDataObject = {
       id: obj.metadata.uid,
       name: obj.metadata.name,
-      type: MANAGED_KAFKA_TOPOLOGY_TYPE,
+      type: TYPE_MANAGED_KAFKA_CONNECTION,
       resource: obj,
       // resources is poorly named, should be overviewItem, eventually going away.
       resources: createOverviewItem(obj),
@@ -45,16 +51,65 @@ export const getTopologyRhoasNodes = (kafkaConnections: K8sResourceKind[]): Node
         resource: obj,
       },
     };
-    nodes.push(getTopologyNodeItem(obj, MANAGED_KAFKA_TOPOLOGY_TYPE, data, KAFKA_PROPS));
+    nodes.push(getTopologyNodeItem(obj, TYPE_MANAGED_KAFKA_CONNECTION, data, KAFKA_PROPS));
   }
 
   return nodes;
 };
 
+export const getRhoasServiceBindingEdges = (
+  dc: K8sResourceKind,
+  rhoasNodes: NodeModel[],
+  sbrs: K8sResourceKind[],
+): EdgeModel[] => {
+  const edges = [];
+  if (!sbrs?.length || !rhoasNodes?.length) {
+    return edges;
+  }
+
+  edgesFromServiceBinding(dc, sbrs).forEach((sbr) => {
+    sbr.spec.services?.forEach((bss) => {
+      if (bss) {
+        const targetNode = rhoasNodes.find(
+          (node) =>
+            node.data.resource.kind === bss.kind && node.data.resource.metadata.name === bss.name,
+        );
+        if (targetNode) {
+          const target = targetNode.data.resource.metadata.uid;
+          const source = dc.metadata.uid;
+          if (source && target) {
+            edges.push({
+              id: `${source}_${target}`,
+              type: TYPE_SERVICE_BINDING,
+              source,
+              target,
+              resource: sbr,
+              data: { sbr },
+            });
+          }
+        }
+      }
+    });
+  });
+
+  return edges;
+};
 export const getRhoasTopologyDataModel = () => (
   namespace: string,
   resources: TopologyDataResources,
-): Promise<Model> =>
-  Promise.resolve({
+  workloads: K8sResourceKind[],
+): Promise<Model> => {
+  const serviceBindingRequests = resources?.serviceBindingRequests?.data;
+  const rhoasDataModel: Model = {
     nodes: getTopologyRhoasNodes(resources.kafkaConnections.data),
-  });
+    edges: [],
+  };
+  if (rhoasDataModel.nodes?.length) {
+    workloads.forEach((dc) => {
+      rhoasDataModel.edges.push(
+        ...[...getRhoasServiceBindingEdges(dc, rhoasDataModel.nodes, serviceBindingRequests)],
+      );
+    });
+  }
+  return Promise.resolve(rhoasDataModel);
+};


### PR DESCRIPTION
Added function to determine SBRs connected to the Managed Kafka Connections.
Removed `MANAGED_KAFKA_TOPOLOGY_TYPE` constant to avoid confusion (changing this would require the same change to be made to `TYPE_MANAGED_KAFKA_CONNECTION`).